### PR TITLE
Ability to ignore field names if specified. 

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,20 +1,23 @@
-module.exports = function(obj) {
-    if (typeof obj === 'string') return camelCase(obj);
-    return walk(obj);
+module.exports = function(obj, ignored) {
+    if (typeof obj === 'string') return camelCase(obj, ignored);
+    return walk(obj, ignored);
 };
 
-function walk (obj) {
+function walk (obj, ignored) {
     if (!obj || typeof obj !== 'object') return obj;
     if (isDate(obj) || isRegex(obj)) return obj;
-    if (isArray(obj)) return map(obj, walk);
+    if (isArray(obj)) return map(obj, function(obj) {  return walk(obj, ignored) });
     return reduce(objectKeys(obj), function (acc, key) {
-        var camel = camelCase(key);
-        acc[camel] = walk(obj[key]);
+        var camel = camelCase(key, ignored);
+        acc[camel] = walk(obj[key], ignored);
         return acc;
     }, {});
 }
 
-function camelCase(str) {
+function camelCase(str, ignored) {
+    if (ignored && ignored.indexOf(str) !== -1) {
+        return str;
+    }
     return str.replace(/[_.-](\w|$)/g, function (_,x) {
         return x.toUpperCase();
     });

--- a/readme.markdown
+++ b/readme.markdown
@@ -28,7 +28,41 @@ output:
   "feeFieFoe": "fum",
   "beepBoop": [
     {
-      "abcXyz": "mno"
+      "abcXyz": "mno",
+    },
+    {
+      "fooBar": "baz"
+    }
+  ]
+}
+```
+
+Also supports ignoring certain keys by passing an array of key names to ignore.  Useful for mongo "_id" fields.
+
+``` js
+var camelize = require('camelize');
+var obj = {
+    _id: "abc123",
+    fee_fie_foe: 'fum',
+    beep_boop: [
+        { 'abc.xyz': 'mno', _id: "def456" },
+        { 'foo-bar': 'baz' }
+    ]
+};
+var res = camelize(obj, ["_id"]);
+console.log(JSON.stringify(res, null, 2));
+```
+
+output
+
+```
+{
+  "_id": "abc123",
+  "feeFieFoe": "fum",
+  "beepBoop": [
+    {
+      "abcXyz": "mno",
+      "_id": "def456"
     },
     {
       "fooBar": "baz"
@@ -43,9 +77,11 @@ output:
 var camelize = require('camelize')
 ```
 
-## camelize(obj)
+## camelize(obj, [ignore])
 
 Convert the key strings in `obj` to camel-case recursively.
+
+If provided, the second parameter should be an array of keys to ignore (leave as-is) when converting.
 
 # install
 

--- a/test/camel.js
+++ b/test/camel.js
@@ -44,3 +44,24 @@ test('only camelize strings that are the root value', function (t) {
     var res = camelize({ 'foo-bar': 'baz-foo' });
     t.deepEqual(res, { fooBar: 'baz-foo' });
 });
+
+test('ignore keys if specified', function(t) {
+    t.plan(1);
+    var res = camelize({ 
+        'foo-bar' : 'baz', 
+        '_test' : 'stuff',
+        'baz-qux': {
+            "_thing" : "some value"
+        }
+
+    }, ['_test', '_thing']);
+
+    t.deepEqual(res, { 
+        'fooBar' : 'baz', 
+        '_test' : 'stuff',
+        'bazQux': {
+            "_thing" : "some value"
+        }
+    })
+
+})


### PR DESCRIPTION
I needed the ability to ignore mogno "_id" properties, so I create a fork to add support for ignoring certain keys.

This works by passing an optional second parameter to the camelize function.  The parameter should be an array of keys to be ignored.  
