### PR TITLE
Ability to ignore field names if specified.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/index.js
+++ b/index.js
@@ -1,21 +1,23 @@
-module.exports = function(obj, ignored) {
-    if (typeof obj === 'string') return camelCase(obj, ignored);
-    return walk(obj, ignored);
+module.exports = function(obj, options) {
+    options = options || {};
+    if (typeof obj === 'string') return camelCase(obj, options);
+    return walk(obj, options);
 };
 
-function walk (obj, ignored) {
+function walk (obj, options) {
     if (!obj || typeof obj !== 'object') return obj;
     if (isDate(obj) || isRegex(obj)) return obj;
-    if (isArray(obj)) return map(obj, function(obj) {  return walk(obj, ignored) });
+    if (isArray(obj)) return map(obj, function(obj) {  return walk(obj, options) });
     return reduce(objectKeys(obj), function (acc, key) {
-        var camel = camelCase(key, ignored);
-        acc[camel] = walk(obj[key], ignored);
+        var camel = camelCase(key, options);
+        acc[camel] = walk(obj[key], options);
         return acc;
     }, {});
 }
 
-function camelCase(str, ignored) {
-    if (ignored && ignored.indexOf(str) !== -1) {
+function camelCase(str, options) {
+    
+    if (options.ignore && options.ignore.indexOf(str) !== -1) {
         return str;
     }
     return str.replace(/[_.-](\w|$)/g, function (_,x) {

--- a/index.js
+++ b/index.js
@@ -1,20 +1,23 @@
-module.exports = function(obj) {
-    if (typeof obj === 'string') return camelCase(obj);
-    return walk(obj);
+module.exports = function(obj, ignored) {
+    if (typeof obj === 'string') return camelCase(obj, ignored);
+    return walk(obj, ignored);
 };
 
-function walk (obj) {
+function walk (obj, ignored) {
     if (!obj || typeof obj !== 'object') return obj;
     if (isDate(obj) || isRegex(obj)) return obj;
-    if (isArray(obj)) return map(obj, walk);
+    if (isArray(obj)) return map(obj, function(obj) {  return walk(obj, ignored) });
     return reduce(objectKeys(obj), function (acc, key) {
-        var camel = camelCase(key);
-        acc[camel] = walk(obj[key]);
+        var camel = camelCase(key, ignored);
+        acc[camel] = walk(obj[key], ignored);
         return acc;
     }, {});
 }
 
-function camelCase(str) {
+function camelCase(str, ignored) {
+    if (ignored && ignored.indexOf(str) !== -1) {
+        return str;
+    }
     return str.replace(/[_.-](\w|$)/g, function (_,x) {
         return x.toUpperCase();
     });

--- a/readme.markdown
+++ b/readme.markdown
@@ -37,7 +37,7 @@ output:
 }
 ```
 
-Also supports ignoring certain keys by passing an array of key names to ignore.  Useful for mongo "_id" fields.
+Also supports ignoring certain keys by second parameter.  This parameter should be an object with an "ignore" property, which is an array of key names to ignore.  Useful for mongo "_id" fields.
 
 ``` js
 var camelize = require('camelize');
@@ -49,7 +49,7 @@ var obj = {
         { 'foo-bar': 'baz' }
     ]
 };
-var res = camelize(obj, ["_id"]);
+var res = camelize(obj, { ignore: ["_id"] });
 console.log(JSON.stringify(res, null, 2));
 ```
 
@@ -77,11 +77,13 @@ output
 var camelize = require('camelize')
 ```
 
-## camelize(obj, [ignore])
+## camelize(obj, [options])
 
 Convert the key strings in `obj` to camel-case recursively.
 
-If provided, the second parameter should be an array of keys to ignore (leave as-is) when converting.
+If provided, the second parameter should be an object that can have the following properties
+
+- ignore: should be an array of keys to ignore (leave as-is) when converting.
 
 # install
 

--- a/readme.markdown
+++ b/readme.markdown
@@ -28,7 +28,41 @@ output:
   "feeFieFoe": "fum",
   "beepBoop": [
     {
-      "abcXyz": "mno"
+      "abcXyz": "mno",
+    },
+    {
+      "fooBar": "baz"
+    }
+  ]
+}
+```
+
+Also supports ignoring certain keys by passing an array of key names to ignore.  Useful for mongo "_id" fields.
+
+``` js
+var camelize = require('camelize');
+var obj = {
+    _id: "abc123",
+    fee_fie_foe: 'fum',
+    beep_boop: [
+        { 'abc.xyz': 'mno', _id: "def456" },
+        { 'foo-bar': 'baz' }
+    ]
+};
+var res = camelize(obj, ["_id"]);
+console.log(JSON.stringify(res, null, 2));
+```
+
+output
+
+```
+{
+  "_id": "abc123",
+  "feeFieFoe": "fum",
+  "beepBoop": [
+    {
+      "abcXyz": "mno",
+      "_id": "def456"
     },
     {
       "fooBar": "baz"
@@ -43,9 +77,11 @@ output:
 var camelize = require('camelize')
 ```
 
-## camelize(obj)
+## camelize(obj, [ignore])
 
 Convert the key strings in `obj` to camel-case recursively.
+
+If provided, the second parameter should be an array of keys to ignore (leave as-is) when converting.
 
 # install
 

--- a/test/camel.js
+++ b/test/camel.js
@@ -54,7 +54,7 @@ test('ignore keys if specified', function(t) {
             "_thing" : "some value"
         }
 
-    }, ['_test', '_thing']);
+    }, { ignore: ['_test', '_thing'] });
 
     t.deepEqual(res, { 
         'fooBar' : 'baz', 

--- a/test/camel.js
+++ b/test/camel.js
@@ -44,3 +44,24 @@ test('only camelize strings that are the root value', function (t) {
     var res = camelize({ 'foo-bar': 'baz-foo' });
     t.deepEqual(res, { fooBar: 'baz-foo' });
 });
+
+test('ignore keys if specified', function(t) {
+    t.plan(1);
+    var res = camelize({ 
+        'foo-bar' : 'baz', 
+        '_test' : 'stuff',
+        'baz-qux': {
+            "_thing" : "some value"
+        }
+
+    }, ['_test', '_thing']);
+
+    t.deepEqual(res, { 
+        'fooBar' : 'baz', 
+        '_test' : 'stuff',
+        'bazQux': {
+            "_thing" : "some value"
+        }
+    })
+
+})


### PR DESCRIPTION
I needed the ability to ignore mogno `_id` properties, so I create a fork to add support for ignoring certain keys.

This works by passing an optional second parameter to the `camelize` function. This parameter is an object (hash) of options.  The only supported option currently is called `ignore` which should be an array of keys to be ignored.

Making this second argument to the `camelize` function an object hash makes things more extensible by making it easy to add new options easier in the future. 

Tests and readme documentation have been updated to reflect these changes.
