### PR TITLE
provide a way to pass in the regex

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,21 +1,24 @@
-module.exports = function(obj) {
-    if (typeof obj === 'string') return camelCase(obj);
-    return walk(obj);
+module.exports = function(obj, regex) {
+    if (typeof obj === 'string') return camelCase(obj, regex);
+    return walk(obj, regex);
 };
 
-function walk (obj) {
+function walk (obj, regex) {
     if (!obj || typeof obj !== 'object') return obj;
     if (isDate(obj) || isRegex(obj)) return obj;
-    if (isArray(obj)) return map(obj, walk);
+    if (isArray(obj)) return map(obj, function (item) {
+        return walk(item, regex);
+    });
     return reduce(objectKeys(obj), function (acc, key) {
-        var camel = camelCase(key);
-        acc[camel] = walk(obj[key]);
+        var camel = camelCase(key, regex);
+        acc[camel] = walk(obj[key], regex);
         return acc;
     }, {});
 }
 
-function camelCase(str) {
-    return str.replace(/[_.-](\w|$)/g, function (_,x) {
+function camelCase (str, regex) {
+    regex = regex || /[_.-](\w|$)/g;
+    return str.replace(regex, function (_,x) {
         return x.toUpperCase();
     });
 }

--- a/readme.markdown
+++ b/readme.markdown
@@ -43,9 +43,9 @@ output:
 var camelize = require('camelize')
 ```
 
-## camelize(obj)
+## camelize(obj, regex)
 
-Convert the key strings in `obj` to camel-case recursively.
+Convert the key strings in `obj` to camel-case recursively. `regex` defaults to `/[_.-](\w|$)/g`.
 
 # install
 

--- a/test/camel.js
+++ b/test/camel.js
@@ -21,6 +21,18 @@ test('camelize a nested object', function (t) {
     });
 });
 
+test('camelize with given regex', function(t) {
+    t.plan(1);
+    var res = camelize(obj, /[_](\w|$)/g);
+    t.deepEqual(res, {
+        "feeFieFoe": "fum",
+        "beepBoop": [
+            { "abc.xyz": "mno" },
+            { "foo-bar": "baz" }
+        ]
+    });
+});
+
 test('string', function (t) {
     t.plan(1);
     t.equal(camelize('one_two'), 'oneTwo');


### PR DESCRIPTION
My object had UUIDs as keys, and I wanted to keep the dashes in them. This allows me to take turn this

```
{
  users: {
    "6b1f4cfb-5193-4676-80f4-4faa0e86ab5c": {
      channel_id: "123"
    }
  }
}
```

into this

```
{
  users: {
    "6b1f4cfb-5193-4676-80f4-4faa0e86ab5c": {
      channelId: "123"
    }
  }
}
```
