### PR TITLE
add support for circular references

### DIFF
--- a/readme.markdown
+++ b/readme.markdown
@@ -47,6 +47,12 @@ var camelize = require('camelize')
 
 Convert the key strings in `obj` to camel-case recursively.
 
+## camelize.circular(obj)
+
+Works just like `camelize`, but works with and preserves circular references.
+If `camelize(obj)` throws a "Maximum call stack size exceeded" error, try this.
+Somewhat slower than `camelize()`, so only use it if it's necessary.
+
 # install
 
 With [npm](https://npmjs.org) do:

--- a/test/camel.js
+++ b/test/camel.js
@@ -44,3 +44,24 @@ test('only camelize strings that are the root value', function (t) {
     var res = camelize({ 'foo-bar': 'baz-foo' });
     t.deepEqual(res, { fooBar: 'baz-foo' });
 });
+
+test('circular object', function (t) {
+    t.plan(2);
+    var circular = { 'child-node': {} };
+    circular['child-node']['parent-node'] = circular;
+    var res = camelize.circular(circular);
+    t.ok(res.childNode, 'childNode exists');
+    t.equal(res.childNode.parentNode, res);
+});
+
+test('circular array', function (t) {
+    t.plan(4);
+    var circular = { 'child-nodes': [{}] };
+    circular['child-nodes'][0]['parent-node'] = circular['child-nodes'];
+    circular['child-nodes'][0]['grandparent-node'] = circular;
+    var res = camelize.circular(circular);
+    t.ok(res.childNodes, 'childNodes exists');
+    t.ok(res.childNodes[0], 'childNodes[0] exists');
+    t.equal(res.childNodes[0].parentNode, res.childNodes);
+    t.equal(res.childNodes[0].grandparentNode, res);
+});


### PR DESCRIPTION
Add a `camelize.circular()` method to use a slightly slower implementation that handles and preserves circular references. Use a `WeakMap`where supported for best performance.
