### PR TITLE
support camelizing STRINGS_LIKE_THIS

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,7 +15,7 @@ function walk (obj) {
 }
 
 function camelCase(str) {
-    return str.replace(/[_.-](\w|$)/g, function (_,x) {
+    return str.toLowerCase().replace(/[_.-](\w|$)/g, function (_,x) {
         return x.toUpperCase();
     });
 }

--- a/test/camel.js
+++ b/test/camel.js
@@ -26,6 +26,11 @@ test('string', function (t) {
     t.equal(camelize('one_two'), 'oneTwo');
 });
 
+test('capitalized string', function (t) {
+    t.plan(1);
+    t.equal(camelize('ONE_TWO'), 'oneTwo');
+});
+
 test('date', function (t) {
     t.plan(1);
     var d = new Date();


### PR DESCRIPTION
Previously `CAPITALIZED_STRINGS` would transform to `CAPITALIZEDSTRINGS`, now transforms correctly to `capitalizedStrings`.