### PR TITLE
Add acronyms option to replace specific strings

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,8 +18,10 @@ function camelCase(str, opts) {
     opts = opts || {};
     var acronyms = opts.acronyms || {};
     var transform = opts.transform;
+    var skip = opts.skip;
     var acronymsKeys = Object.keys(acronyms);
 
+    if (skip && skip.test(str)) return str;
     if (transform) return transform(str);
 
     return str.replace(/[_.-]([^_.-]+|$)/g, function (_,x) {

--- a/index.js
+++ b/index.js
@@ -15,10 +15,16 @@ function walk (obj, opts) {
 }
 
 function camelCase(str, opts) {
-    var acronyms = (opts || {}).acronyms || {};
+    opts = opts || {};
+    var acronyms = opts.acronyms || {};
+    var transform = opts.transform;
     var acronymsKeys = Object.keys(acronyms);
+
+    if (transform) return transform(str);
+
     return str.replace(/[_.-]([^_.-]+|$)/g, function (_,x) {
         if (acronymsKeys.indexOf(x) > -1) return acronyms[x];
+
         return x.substr(0, 1).toUpperCase() + x.substr(1);
     });
 }

--- a/package.json
+++ b/package.json
@@ -19,14 +19,28 @@
         "json",
         "transform"
     ],
-    "testling" : {
-        "files" : "test/*.js",
-        "browsers" : {
-            "iexplore" : [ "6.0", "7.0", "8.0", "9.0" ],
-            "chrome" : [ "20.0" ],
-            "firefox" : [ "10.0", "15.0" ],
-            "safari" : [ "5.1" ],
-            "opera" : [ "12.0" ]
+    "testling": {
+        "files": "test/*.js",
+        "browsers": {
+            "iexplore": [
+                "6.0",
+                "7.0",
+                "8.0",
+                "9.0"
+            ],
+            "chrome": [
+                "20.0"
+            ],
+            "firefox": [
+                "10.0",
+                "15.0"
+            ],
+            "safari": [
+                "5.1"
+            ],
+            "opera": [
+                "12.0"
+            ]
         }
     },
     "author": {

--- a/readme.markdown
+++ b/readme.markdown
@@ -43,9 +43,34 @@ output:
 var camelize = require('camelize')
 ```
 
-## camelize(obj)
+## camelize(obj, opts = {})
 
 Convert the key strings in `obj` to camel-case recursively.
+
+### options
+
+You can pass an object of options. Available options:
+
+- `acronyms`
+
+Replaces found coincidences with their corresponding value:
+
+```js
+var camelize = require('camelize');
+var acronyms = { id: 'ID', url: 'URL' };
+var obj = { id: 1, image_url 'example.com', category_id: 2 };
+var res = camelize(obj, { acronyms: acronyms });
+```
+
+output:
+
+```json
+{
+  "id": 1,
+  "imageURL": "example.com",
+  "categoryID": 2
+}
+```
 
 # install
 

--- a/readme.markdown
+++ b/readme.markdown
@@ -72,6 +72,26 @@ output:
 }
 ```
 
+- `transform`
+
+Uses passed function to transform key:
+
+```js
+var camelize = require('camelize'):
+var transform = function(x) { return x.replace(/\d/g, 'x'); }
+var obj = { id: 1, foo1: 'bar' };
+var res = camelize(obj, { transform: transform });
+```
+
+output:
+
+```json
+{
+  "id": 1,
+  "foox": "bar"
+}
+```
+
 # install
 
 With [npm](https://npmjs.org) do:

--- a/readme.markdown
+++ b/readme.markdown
@@ -92,6 +92,26 @@ output:
 }
 ```
 
+- `skip`
+
+Skips transformation if key matches passed regex.
+
+```js
+var camelize = require('camelize'):
+var skip = /\d{4}-\d{1,2}-\d{1,2}/;
+var obj = { id: 1, '1970-01-01': 'bar' };
+var res = camelize(obj, { skip: skip });
+```
+
+output:
+
+```json
+{
+  "id": 1,
+  "1970-01-01": "bar"
+}
+```
+
 # install
 
 With [npm](https://npmjs.org) do:

--- a/test/camel.js
+++ b/test/camel.js
@@ -57,3 +57,13 @@ test('uses passed acronyms', function(t) {
     var arr = camelize(['my_id'], opts);
     t.deepEqual(arr, ['my_id']);
 });
+
+test('uses transform function passed', function(t) {
+    var opts = {
+      transform: function (x) { return 'foo'; },
+    };
+
+    t.plan(1);
+    t.equal(camelize('bar', opts), 'foo');
+});
+

--- a/test/camel.js
+++ b/test/camel.js
@@ -44,3 +44,16 @@ test('only camelize strings that are the root value', function (t) {
     var res = camelize({ 'foo-bar': 'baz-foo' });
     t.deepEqual(res, { fooBar: 'baz-foo' });
 });
+
+test('uses passed acronyms', function(t) {
+    var opts = { acronyms: { id: 'ID' } };
+
+    t.plan(3);
+    t.equal(camelize('my_id', opts), 'myID');
+
+    var obj = camelize({ 'my_id': 'nested', 'id': 'foo' }, opts);
+    t.deepEqual(obj, { myID: 'nested', id: 'foo' });
+
+    var arr = camelize(['my_id'], opts);
+    t.deepEqual(arr, ['my_id']);
+});

--- a/test/camel.js
+++ b/test/camel.js
@@ -67,3 +67,12 @@ test('uses transform function passed', function(t) {
     t.equal(camelize('bar', opts), 'foo');
 });
 
+test('skips matching keys', function(t) {
+    var opts = {
+      skip: /\d{4}-\d{1,2}-\d{1,2}/,
+    };
+
+    t.plan(1);
+    t.equal(camelize('1970-01-01', opts), '1970-01-01');
+});
+


### PR DESCRIPTION
This PR adds the option to specify certain acronyms:

```js
var camelize = require('camelize');
var acronyms = { id: 'ID', url: 'URL' };
var obj = { id: 1, image_url 'example.com', category_id: 2 };
var res = camelize(obj, { acronyms: acronyms });
```

output:

```json
{
  "id": 1,
  "imageURL": "example.com",
  "categoryID": 2
}
```